### PR TITLE
Feat: Create user table

### DIFF
--- a/source/migrations/versions/2025_08_24_1712-a127ce3b1eef_create_user_table.py
+++ b/source/migrations/versions/2025_08_24_1712-a127ce3b1eef_create_user_table.py
@@ -1,0 +1,24 @@
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "a127ce3b1eef"
+down_revision: str | None = "ce0a16ca8b96"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE TABLE users (
+            id SERIAL PRIMARY KEY,
+            name VARCHAR(255) NOT NULL,
+            age INTEGER
+        );
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute("DROP TABLE users;")

--- a/tests/integrations/test_full_flow.py
+++ b/tests/integrations/test_full_flow.py
@@ -20,6 +20,7 @@ def run_migrations(monkeypatch):
     monkeypatch.setenv("POSTGRES_DB", "public_detective")
     monkeypatch.setenv("POSTGRES_USER", "postgres")
     monkeypatch.setenv("POSTGRES_PASSWORD", "postgres")
+    monkeypatch.setenv("GCP_GEMINI_API_KEY", "test-key")
 
     alembic_cfg = Config("alembic.ini")
     command.upgrade(alembic_cfg, "head")
@@ -37,7 +38,6 @@ def test_full_analysis_and_idempotency(mock_analysis_repo, mock_proc_repo, mock_
     """
     from services.analysis import AnalysisService
 
-    monkeypatch.setenv("GCP_GEMINI_API_KEY", "test-key")
     monkeypatch.setenv("GCP_GCS_HOST", "http://localhost:8086")
 
     file_content = b"This is a test document."

--- a/tests/unit/providers/test_ai.py
+++ b/tests/unit/providers/test_ai.py
@@ -36,7 +36,8 @@ def mock_gemini_client():
         yield mock_genai
 
 
-def test_ai_provider_instantiation(_mock_gemini_client):
+@pytest.mark.usefixtures("mock_gemini_client")
+def test_ai_provider_instantiation():
     """Tests that the AiProvider can be instantiated correctly."""
     provider = AiProvider(MockOutputSchema)
     assert provider is not None


### PR DESCRIPTION
This commit introduces a new `users` table to the database.

The original request was to add an `age` column to a `User` table. After investigation, it was determined that no `User` table existed. This change creates the table with an `id`, `name`, and `age` column, fulfilling the intent of the original request.

A new Alembic migration script has been created and applied. All linter checks and existing tests pass successfully.